### PR TITLE
CI for building test & Release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+**.md
+node_modules
+.gitignore
+.idea
+.github
+.vscode

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,57 @@
+name: Nephelios-Front CI Build
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "**.md"
+      - "ci-release.yml"
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - "**.md"
+      - "ci-release.yml"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container # Utilisation du bon driver pour gérer le cache
+
+      - name: Dockerhub login
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_NEPHELIOS_FRONT_USER }}
+          password: ${{ secrets.DOCKER_NEPHELIOS_FRONT_TOKEN }}
+
+      - name: Build Docker image
+        id: build-image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          tags: zuhowks/nephelios-front:unstable
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          github-token: ${{ secrets.TOKEN_GITHUB }}
+          load: true

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -27,11 +27,23 @@ jobs:
             node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
 
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          version: 10
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Build
-        run: npm run build
+        run: pnpm run build
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -1,0 +1,58 @@
+name: Nephelios-Front CI Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Extract version from tag
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+
+      - name: Validate package.json version (without jq)
+        run: |
+          FILE_VERSION=$(grep '"version"' package.json | head -1 | cut -d '"' -f4)
+          if [ "$FILE_VERSION" != "$VERSION" ]; then
+            echo "❌ package.json version ($FILE_VERSION) does not match tag version ($VERSION)"
+            exit 1
+          else
+            echo "✅ package.json version matches tag version ($VERSION)"
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container # Utilisation du bon driver pour gérer le cache
+
+      - name: Dockerhub login
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_NEPHELIOS_FRONT_USER }}
+          password: ${{ secrets.DOCKER_NEPHELIOS_FRONT_TOKEN }}
+
+      - name: Build Docker image
+        id: build-image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            zuhowks/nephelios-front:${{ env.VERSION }}
+            zuhowks/nephelios-front:latest
+          cache-from: type=gha
+          github-token: ${{ secrets.TOKEN_GITHUB }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM node:22-slim AS base
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+COPY . /app
+RUN corepack enable
+WORKDIR /app
+RUN pnpm install -g http-server
+
+# All deps stage
+FROM base AS deps
+ADD package.json package-lock.json ./
+
+# Production only deps stage
+FROM base AS production-deps
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --prod --frozen-lockfile
+
+# Build stage
+FROM base AS build
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
+RUN pnpm run build
+
+FROM base
+ENV NODE_ENV=production
+COPY --from=production-deps /app/node_modules /app/node_modules
+COPY --from=build /app/dist /app/dist
+EXPOSE 80
+CMD [ "http-server", "dist", "-p", "80" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  nephelios-front:
+    container_name: nephelios-front
+    build: .
+    ports:
+      - "80:80"


### PR DESCRIPTION
This pull request includes significant updates to the CI/CD pipeline and Docker configurations for the Nephelios-Front project. The changes aim to streamline the build and deployment processes, as well as to ensure that certain files and directories are ignored during Docker builds.

### CI/CD Pipeline Enhancements:

* [`.github/workflows/ci-build.yml`](diffhunk://#diff-68ba9d12f6f2601fe3c9f7f9d0d02aaea52384559d6d08fae7afc941663fdfcdR1-R69): Added a new CI build workflow for the Nephelios-Front project, including steps for checking out the code, caching dependencies, installing Node.js and pnpm, building the project, and setting up Docker Buildx.
* [`.github/workflows/ci-release.yml`](diffhunk://#diff-42a22ead44f8caf1b1f3555b7f6d50edc89d0f4ebe837b593542de41b1fd2ca8R1-R58): Introduced a CI release workflow that triggers on tag pushes, validates the `package.json` version against the tag version, and builds and pushes Docker images to Dockerhub.

### Docker Configuration Updates:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R27): Created a multi-stage Dockerfile to handle different stages such as base setup, dependency installation, build, and final production image creation.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R1-R6): Added a Docker Compose configuration to define the `nephelios-front` service, specifying the container name, build context, and port mappings.

### Miscellaneous:

* [`.dockerignore`](diffhunk://#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5R1-R6): Added a `.dockerignore` file to exclude unnecessary files and directories from Docker builds, such as markdown files, node_modules, and various configuration directories.